### PR TITLE
Basic source_location formatter & tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.5)
+project(SourceLocationFormatter)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_COMPILER "/usr/local/bin/g++-14")
+
+include_directories(include)
+
+add_executable(main src/main.cpp)
+
+# Fetch GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# Link GoogleTest to the test target
+enable_testing()
+add_executable(test_source_location_formatter tests/test_source_location_formatter.cpp)
+target_link_libraries(test_source_location_formatter gtest gtest_main gmock gmock_main)
+
+add_test(NAME test_source_location_formatter COMMAND test_source_location_formatter)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# formatting
+# Source Location Formatter
+
+This repo provides a template specialization of `std::formatter` for `std::source_location`, allowing users to covert a `source_location` to a textual representation of its data members (`file_name`, `line_number`, `column_number`, and `function_name` at the time of this writing).
+
+### Prerequisites
+
+- a C++20 that supports `std::format` and `std::source_location` (e.g., GCC gcc 13, Clang 16)
+- CMake 3.10+
+- GoogleTest (for testing)
+
+### Building
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+### Running Tests
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+make test
+```
+
+### Usage
+
+```cpp
+#include "source_location_formatter.h"
+#include <iostream>
+
+int main() {
+    std::cout << std::format("Current location: {}",
+                             std::source_location::current());
+}
+```
+

--- a/include/source_location_formatter.h
+++ b/include/source_location_formatter.h
@@ -1,0 +1,18 @@
+#ifndef SOURCE_LOCATION_FORMATTER_H
+#define SOURCE_LOCATION_FORMATTER_H
+
+#include <format>
+#include <source_location>
+#include <string>
+
+template <>
+struct std::formatter<std::source_location> : std::formatter<std::string> {
+    auto format(const std::source_location& loc,
+                std::format_context& ctx) const {
+        return std::format_to(ctx.out(), "{}, {}, {}, {}", loc.file_name(),
+                              loc.line(), loc.column(), loc.function_name());
+    }
+};
+
+#endif // SOURCE_LOCATION_FORMATTER_H
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,8 @@
+#include "source_location_formatter.h"
+#include <iostream>
+
+int main() {
+    std::cout << std::format("Current location: {}",
+                             std::source_location::current()) << '\n';
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(test_source_location_formatter test_source_location_formatter.cpp)
+target_link_libraries(test_source_location_formatter gtest gtest_main)
+add_test(NAME test_source_location_formatter COMMAND test_source_location_formatter)
+

--- a/tests/test_source_location_formatter.cpp
+++ b/tests/test_source_location_formatter.cpp
@@ -1,0 +1,27 @@
+#include "source_location_formatter.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <string>
+
+TEST(SourceLocationFormatter, BasicTest) {
+    auto loc { std::source_location::current() };
+    std::string result = std::format("Location: {}", loc);
+    ASSERT_THAT(result, testing::StartsWith("Location: "))
+        << "Literal included";
+    ASSERT_THAT(result, testing::MatchesRegex(
+        "^.*test_source_location_formatter\\.cpp.*$"
+    )) << "File name included";
+    // Known issue with gtest: https://github.com/google/googletest/issues/3084
+    // TLDR: \\d doesn't work on MacOS or Linux, but [0-9] won't work on Windows
+    ASSERT_THAT(result, testing::MatchesRegex("^.*[0-9]+,.+[0-9]+.*$"))
+        << "Line and column numbers included";
+    ASSERT_THAT(result, testing::MatchesRegex("^.*TestBody().*$"))
+        << "Function name included";
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
 - adds `include/source_location_formatter.h`
   - which contains a template specialization for `std::source_location`
     that inherits from the `string` formatter template specialization
 - adds a few unit tests in `tests/test_source_location_formatter.cpp`
 - adds the necessary CMakeLists.txt files for building and testing
 - adds an example file (`/src/main.cpp`) to showcase the usage of the
   formatter
 - updates the `README.md` file to explain the project and inform users
   how to build and test